### PR TITLE
deps: bump nodejs used for action to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,5 +17,5 @@ branding:
   icon: 'circle'
   color: 'red'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
This is required as GitHub is deprecated `nodejs12` from the runners.

Signed-off-by: Avi Miller <avi.miller@oracle.com>