### PR TITLE
fix: kubectl not executable

### DIFF
--- a/.github/workflows/test-configure-kubectl-oke-action.yml
+++ b/.github/workflows/test-configure-kubectl-oke-action.yml
@@ -20,7 +20,7 @@ jobs:
       OCI_CLI_KEY_CONTENT: ${{ secrets.OCI_CLI_KEY_CONTENT }}
       OCI_CLI_REGION: ${{ secrets.OCI_CLI_REGION }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Configure Kubectl for OKE cluster in home region
         uses: ./
@@ -42,7 +42,7 @@ jobs:
       OCI_CLI_REGION: ${{ secrets.OCI_CLI_NEW_REGION }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Configure Kubectl for OKE cluster in new region
         uses: ./
         id: test-configure-kubectl-oke-action-new-region

--- a/.github/workflows/test-configure-kubectl-oke-action.yml
+++ b/.github/workflows/test-configure-kubectl-oke-action.yml
@@ -28,6 +28,11 @@ jobs:
         with:
           cluster: ${{ secrets.OKE_CLUSTER_ID }}
 
+      - name: Check that the correct kubectl version is active
+        run: |
+          which kubectl
+          kubectl version --short
+
       - name: Get pods using Kubectl
         run: kubectl get pods -A
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -44472,7 +44472,7 @@ function getKubectl(version) {
             const kubectl = yield _actions_tool_cache__WEBPACK_IMPORTED_MODULE_5__.downloadTool(`https://storage.googleapis.com/kubernetes-release/release/${version}/bin/linux/amd64/kubectl`);
             cachedKubectl = yield _actions_tool_cache__WEBPACK_IMPORTED_MODULE_5__.cacheFile(kubectl, 'kubectl', 'kubectl', version);
         }
-        fs__WEBPACK_IMPORTED_MODULE_0__.chmodSync(path__WEBPACK_IMPORTED_MODULE_2__.join(cachedKubectl, 'kubectl'), 0o644);
+        fs__WEBPACK_IMPORTED_MODULE_0__.chmodSync(path__WEBPACK_IMPORTED_MODULE_2__.join(cachedKubectl, 'kubectl'), 0o755);
         return cachedKubectl;
     });
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,7 +29,7 @@ async function getKubectl(version: string): Promise<string> {
     cachedKubectl = await tc.cacheFile(kubectl, 'kubectl', 'kubectl', version);
   }
 
-  fs.chmodSync(path.join(cachedKubectl, 'kubectl'), 0o644);
+  fs.chmodSync(path.join(cachedKubectl, 'kubectl'), 0o755);
   return cachedKubectl;
 }
 


### PR DESCRIPTION
Executable bit is not active for kubectl binary
fix #19